### PR TITLE
Add option to skip namespaces based on a regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Docker image by default runs `kube_backup backup && kube_backup push`
 * `BACKUP_VERBOSE` use 1 to enable verbose logging
 * `TARGET_PATH` - local git repository folder, default `./kube_state`
 * `SKIP_NAMESPACES` - namespaces to exclude, separated by coma (,)
+* `SKIP_NAMESPACES_REGEX` - namespaces to exclude, supports a single regex like `/^gitlab-runner-\d+$/` to match `gitlab-runner-1234`
 * `ONLY_NAMESPACES` - whitelist namespaces
 * `GLOBAL_RESOURCES` - override global resources list, default is `node, apiservice, clusterrole, clusterrolebinding, podsecuritypolicy, storageclass, persistentvolume, customresourcedefinition, mutatingwebhookconfiguration, validatingwebhookconfiguration, priorityclass`
 * `EXTRA_GLOBAL_RESOURCES` - use it to add resources to `GLOBAL_RESOURCES` list

--- a/lib/kube_backup.rb
+++ b/lib/kube_backup.rb
@@ -102,6 +102,7 @@ module KubeBackup
     end
 
     skip_namespaces = options[:skip_namespaces] ? options[:skip_namespaces].split(",") : []
+    skip_namespaces_regex = options[:skip_namespaces_regex] ? options[:skip_namespaces_regex] : nil
     only_namespaces = options[:only_namespaces] ? options[:only_namespaces].split(",") : nil
 
     writter = Writter.new(options)
@@ -172,6 +173,12 @@ module KubeBackup
         end
 
         namespace = item.dig("metadata", "namespace")
+
+        if skip_namespaces_regex && namespace.match(skip_namespaces_regex)
+          name = item.dig("metadata", "name")
+          logger.info "skip resource #{namespace}/#{item["kind"]}/#{name} by skip_namespaces_regex filter"
+          next
+        end
 
         if skip_namespaces.include?(namespace)
           name = item.dig("metadata", "name")

--- a/lib/kube_backup/cli.rb
+++ b/lib/kube_backup/cli.rb
@@ -13,7 +13,7 @@ class KubeBackup::CLI
     end
 
     vars = [
-      :target_path, :skip_namespaces, :only_namespaces,
+      :target_path, :skip_namespaces, :skip_namespaces_regex, :only_namespaces,
       :global_resources, :extra_global_resources, :skip_global_resources,
       :resources, :extra_resources, :skip_resources, :skip_objects,
       :git_user, :git_email, :git_branch, :git_prefix


### PR DESCRIPTION
We want to be able to exclude certain namespaces e.g. generated by Gitlab pipelines that include an incremental number.